### PR TITLE
Allow embed the web as an IFrame

### DIFF
--- a/settings/common.py
+++ b/settings/common.py
@@ -101,3 +101,6 @@ MEDIA_URL = '/media/'
 
 STATIC_ROOT = path.join(BASE_DIR, "static")
 MEDIA_ROOT = path.join(BASE_DIR, "media")
+
+# X-Frame options
+X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
It is a potential way to clickjacking but I don't see the web as a potential target for this security issue.

Embedding of the web page as an IFrame allows the inclusion of the web in other places like slides to be used in workshops, conferences,...